### PR TITLE
Include UInt16.MaxValue as medium size frame

### DIFF
--- a/tests/WebSocketListener.UnitTests/With_WebSocketFrameHeader.cs
+++ b/tests/WebSocketListener.UnitTests/With_WebSocketFrameHeader.cs
@@ -34,18 +34,16 @@ namespace WebSocketListenerTests
         }
 
         [TestMethod]
-        public void With_WebSocketFrameHeaderFlags_Can_CreateMediumMaxHeader() // Stef : Length 10 is returned instead of 4 ???
+        public void With_WebSocketFrameHeaderFlags_Can_CreateMediumMaxHeader()
         {
             var header = WebSocketFrameHeader.Create(UInt16.MaxValue, true, false, WebSocketFrameOption.Text, new WebSocketExtensionFlags());
-            Assert.AreEqual(10, header.HeaderLength);
-
-            //Assert.AreEqual(4, header.HeaderLength);
-            //Byte[] buffer = new Byte[4];
-            //header.ToBytes(buffer, 0);
-            //Assert.AreEqual(129, buffer[0]);
-            //Assert.AreEqual(126, buffer[1]);
-            //Assert.AreEqual(255, buffer[2]);
-            //Assert.AreEqual(255, buffer[3]);
+            Assert.AreEqual(4, header.HeaderLength);
+            Byte[] buffer = new Byte[4];
+            header.ToBytes(buffer, 0);
+            Assert.AreEqual(129, buffer[0]);
+            Assert.AreEqual(126, buffer[1]);
+            Assert.AreEqual(255, buffer[2]);
+            Assert.AreEqual(255, buffer[3]);
         }
 
         [TestMethod]

--- a/vtortola.WebSockets.Rfc6455/Header/WebSocketFrameHeader.cs
+++ b/vtortola.WebSockets.Rfc6455/Header/WebSocketFrameHeader.cs
@@ -48,7 +48,7 @@ namespace vtortola.WebSockets.Rfc6455
             if (this.ContentLength <= 125)
             { // header length is included in the 2b header
             }
-            else if (this.ContentLength < UInt16.MaxValue)
+            else if (this.ContentLength <= UInt16.MaxValue)
                 ((UInt16)this.ContentLength).ToBytesBackwards(segment, offset + 2);
             else if ((UInt64)this.ContentLength <= UInt64.MaxValue)
                 ((UInt64)this.ContentLength).ToBytesBackwards(segment, offset + 2);
@@ -147,7 +147,7 @@ namespace vtortola.WebSockets.Rfc6455
                         
             if (count <= 125)
                 headerLength = 2;
-            else if (count < UInt16.MaxValue)
+            else if (count <= UInt16.MaxValue)
                 headerLength = 4;
             else if ((UInt64)count < UInt64.MaxValue)
                 headerLength = 10;

--- a/vtortola.WebSockets.Rfc6455/Header/WebSocketFrameHeaderFlags.cs
+++ b/vtortola.WebSockets.Rfc6455/Header/WebSocketFrameHeaderFlags.cs
@@ -102,7 +102,7 @@ namespace vtortola.WebSockets.Rfc6455
             Int32 headerLength;
             if (length <= 125)
                 headerLength = (Int32)length;
-            else if (length < UInt16.MaxValue)
+            else if (length <= UInt16.MaxValue)
                 headerLength = 126;
             else if ((UInt64)length < UInt64.MaxValue)
                 headerLength = 127;


### PR DESCRIPTION
Hi,

It seems that for whatever reason, you were using the latest version of WSL tests, but the WSL code itself did not merge well or something and this commit was not applied: https://github.com/vtortola/WebSocketListener/commit/cebb66f700db390eea3c4687add2a238394d3da4#diff-6836e9ef5ebf42305ca2ac2ab4377924

I added the changes, and I am doing some testing. Hopefully tomorrow I can do the final merge into master.

Good job by the way 👍 